### PR TITLE
embed libcamera and libfreetype into the component

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 *.o
-text_font.*
-mtxrpicam
-mtxrpicam_*
+/deps
+/prefix
+/mtxrpicam_*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: make -f utils.mk build32
+    - run: make -f utils.mk build_32
+
+    - run: tar -czf mtxrpicam_32.tar.gz mtxrpicam_32
 
     - uses: actions/upload-artifact@v4
       with:
-        path: mtxrpicam_32
-        name: mtxrpicam_32
+        path: mtxrpicam_32.tar.gz
+        name: mtxrpicam_32.tar.gz
 
   build_64:
     runs-on: ubuntu-22.04
@@ -25,12 +27,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: make -f utils.mk build64
+    - run: make -f utils.mk build_64
+
+    - run: tar -czf mtxrpicam_64.tar.gz mtxrpicam_64
 
     - uses: actions/upload-artifact@v4
       with:
-        path: mtxrpicam_64
-        name: mtxrpicam_64
+        path: mtxrpicam_64.tar.gz
+        name: mtxrpicam_64.tar.gz
 
   github_release:
     needs:
@@ -41,12 +45,12 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: mtxrpicam_32
+        name: mtxrpicam_32.tar.gz
         path: binaries/
 
     - uses: actions/download-artifact@v4
       with:
-        name: mtxrpicam_64
+        name: mtxrpicam_64.tar.gz
         path: binaries/
 
     - uses: actions/github-script@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: make -f utils.mk build32
+    - run: make -f utils.mk build_32
 
     - uses: actions/upload-artifact@v4
       with:
@@ -26,14 +26,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: make -f utils.mk build64
+    - run: make -f utils.mk build_64
 
     - uses: actions/upload-artifact@v4
       with:
         path: mtxrpicam_64
         name: mtxrpicam_64
 
-  test_32:
+  test_bullseye_32:
     needs: build_32
     runs-on: ubuntu-22.04
 
@@ -43,13 +43,13 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: mtxrpicam_32
-        path: .
+        path: mtxrpicam_32
 
-    - run: chmod +x mtxrpicam_32
+    - run: chmod +x ./mtxrpicam_32/exe
 
-    - run: make -f utils.mk test32
+    - run: make -f utils.mk test_bullseye_32
 
-  test_64:
+  test_bullseye_64:
     needs: build_64
     runs-on: ubuntu-22.04
 
@@ -59,8 +59,40 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: mtxrpicam_64
-        path: .
+        path: mtxrpicam_64
 
-    - run: chmod +x mtxrpicam_64
+    - run: chmod +x ./mtxrpicam_64/exe
 
-    - run: make -f utils.mk test64
+    - run: make -f utils.mk test_bullseye_64
+
+  test_bookworm_32:
+    needs: build_32
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: mtxrpicam_32
+        path: mtxrpicam_32
+
+    - run: chmod +x ./mtxrpicam_32/exe
+
+    - run: make -f utils.mk test_bookworm_32
+
+  test_bookworm_64:
+    needs: build_64
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: mtxrpicam_64
+        path: mtxrpicam_64
+
+    - run: chmod +x ./mtxrpicam_64/exe
+
+    - run: make -f utils.mk test_bookworm_64

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.o
-text_font.*
-mtxrpicam
-mtxrpicam_*
+/deps
+/prefix
+/mtxrpicam_*

--- a/README.md
+++ b/README.md
@@ -15,12 +15,17 @@ This is embedded into all MediaMTX releases and shouldn't normally be downloaded
    ```sh
    sudo apt install -y \
    g++ \
-   pkg-config \
    make \
-   libcamera-dev \
-   libfreetype-dev \
    xxd \
-   wget
+   wget \
+   git \
+   cmake \
+   meson \
+   patch \
+   pkg-config \
+   python3-jinja2 \
+   python3-yaml \
+   python3-ply
    ```
 
 3. Build:
@@ -29,7 +34,7 @@ This is embedded into all MediaMTX releases and shouldn't normally be downloaded
    make -j$(nproc)
    ```
 
-   This will produce `mtxrpicam_32` or `mtxrpicam_64` (depending on the architecture).
+   This will produce the `mtxrpicam_32` or `mtxrpicam_64` folder (depending on the architecture).
 
 ## Cross-compile
 
@@ -43,9 +48,9 @@ This is embedded into all MediaMTX releases and shouldn't normally be downloaded
    make -f utils.mk build
    ```
 
-   This will produce `mtxrpicam_32` and `mtxrpicam_64`.
+   This will produce the `mtxrpicam_32` and `mtxrpicam_64` folders.
 
-## Installation
+## Install
 
 1. Download MediaMTX source code and open a terminal in it
 

--- a/libcamera.patch
+++ b/libcamera.patch
@@ -1,0 +1,26 @@
+diff --git a/meson.build b/meson.build
+index 58bb9893..41fc661f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2,7 +2,7 @@
+
+ project('libcamera', 'c', 'cpp',
+     meson_version : '>= 0.60',
+-    version : '0.3.0',
++    version : '9.9.9',
+     default_options : [
+         'werror=true',
+         'warning_level=2',
+diff --git a/src/libcamera/meson.build b/src/libcamera/meson.build
+index 89504cee..20c588cb 100644
+--- a/src/libcamera/meson.build
++++ b/src/libcamera/meson.build
+@@ -61,7 +61,7 @@ includes = [
+
+ libcamera_deps = []
+
+-libatomic = cc.find_library('atomic', required : false)
++libatomic = cc.find_library('atomic', required : true, static : true)
+ libthreads = dependency('threads')
+
+ subdir('base')

--- a/main.c
+++ b/main.c
@@ -35,9 +35,7 @@ static void on_encoder_output(uint64_t ts, const uint8_t *buf, uint64_t size) {
 }
 
 int main() {
-    // this is meant to test that dependencies have been loaded correctly
-    // therefore a simple "return 0" is enough.
-    if (strlen(getenv("TEST")) != 0) {
+    if (getenv("TEST") != NULL) {
         printf("test passed\n");
         return 0;
     }
@@ -53,7 +51,7 @@ int main() {
     free(buf);
     if (!ok) {
         pipe_write_error(pipe_video_fd, "parameters_unserialize(): %s", parameters_get_error());
-        return 5;
+        return -1;
     }
 
     pthread_mutex_init(&pipe_video_mutex, NULL);
@@ -66,13 +64,13 @@ int main() {
         &cam);
     if (!ok) {
         pipe_write_error(pipe_video_fd, "camera_create(): %s", camera_get_error());
-        return 5;
+        return -1;
     }
 
     ok = text_create(&params, &text);
     if (!ok) {
         pipe_write_error(pipe_video_fd, "text_create(): %s", text_get_error());
-        return 5;
+        return -1;
     }
 
     ok = encoder_create(
@@ -83,13 +81,13 @@ int main() {
         &enc);
     if (!ok) {
         pipe_write_error(pipe_video_fd, "encoder_create(): %s", encoder_get_error());
-        return 5;
+        return -1;
     }
 
     ok = camera_start(cam);
     if (!ok) {
         pipe_write_error(pipe_video_fd, "camera_start(): %s", camera_get_error());
-        return 5;
+        return -1;
     }
 
     pipe_write_ready(pipe_video_fd);

--- a/text.c
+++ b/text.c
@@ -3,7 +3,8 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
-#include "text_font.h"
+#include "deps/text_font.h"
+
 #include "text.h"
 
 static char errbuf[256];
@@ -42,8 +43,8 @@ bool text_create(const parameters_t *params, text_t **text) {
 
         error = FT_New_Memory_Face(
             textp->library,
-            text_font_ttf,
-            sizeof(text_font_ttf),
+            deps_text_font_ttf,
+            sizeof(deps_text_font_ttf),
             0,
             &textp->face);
         if (error) {

--- a/utils.mk
+++ b/utils.mk
@@ -1,87 +1,121 @@
-RPI32_IMAGE = balenalib/raspberry-pi:bullseye-run-20240508
-RPI64_IMAGE = balenalib/raspberrypi3-64:bullseye-run-20240429
+BULLSEYE_32_IMAGE = balenalib/raspberry-pi:bullseye-run-20240508
+BULLSEYE_64_IMAGE = balenalib/raspberrypi3-64:bullseye-run-20240429
+BOOKWORM_32_IMAGE = balenalib/raspberry-pi:bookworm-run-20240527
+BOOKWORM_64_IMAGE = balenalib/raspberrypi3-64:bookworm-run-20240429
 
 help:
 	@echo "usage: make [action]"
 	@echo ""
 	@echo "available actions:"
 	@echo ""
-	@echo "  build            build binaries for all platforms"
-	@echo "  build32          build binaries for the 64-bit platform"
-	@echo "  build64          build binaries for the 32-bit platform"
-	@echo "  test32           test binaries for the 32-bit platform"
-	@echo "  test64           test binaries for the 64-bit platform"
+	@echo "  build              build binaries for all architectures"
+	@echo "  build_32           build binaries for 64-bit architectures"
+	@echo "  build_64           build binaries for 32-bit architectures"
+	@echo "  test_bullseye_32   test binaries on Raspberry Pi OS Bullseye 32-bit"
+	@echo "  test_bullseye_64   test binaries on Raspberry Pi OS Bullseye 64-bit"
+	@echo "  test_bookworm_32   test binaries on Raspberry Pi OS Bookworm 32-bit"
+	@echo "  test_bookworm_64   test binaries on Raspberry Pi OS Bookworm 64-bit"
 	@echo ""
 
-build: build32 build64
+build: build_32 build_64
 
 enable_multiarch:
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
 
-define DOCKERFILE_BUILD32
+define DOCKERFILE_BUILD_32
 FROM multiarch/qemu-user-static:x86_64-arm AS qemu
-FROM $(RPI32_IMAGE) AS build
+FROM $(BULLSEYE_32_IMAGE) AS build
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 RUN apt update && apt install -y --no-install-recommends \
 	g++ \
-	pkg-config \
 	make \
-	libcamera-dev \
-	libfreetype-dev \
 	xxd \
-	wget
+	wget \
+	git \
+	cmake \
+	meson \
+	patch \
+	pkg-config \
+	python3-jinja2 \
+	python3-yaml \
+	python3-ply
 WORKDIR /s
 COPY . .
 RUN make -j$$(nproc)
 endef
-export DOCKERFILE_BUILD32
+export DOCKERFILE_BUILD_32
 
-build32: enable_multiarch
-	echo "$$DOCKERFILE_BUILD32" | docker build . -f - -t build32
-	docker run --rm -v $(PWD):/o build32 sh -c "mv /s/mtxrpicam_32 /o/"
+build_32: enable_multiarch
+	echo "$$DOCKERFILE_BUILD_32" | docker build . -f - -t build32
+	docker run --rm -v $(PWD):/o build32 sh -c "rm -rf /o/mtxrpicam_32 && mv /s/mtxrpicam_32 /o/"
 
-define DOCKERFILE_BUILD64
+define DOCKERFILE_BUILD_64
 FROM multiarch/qemu-user-static:x86_64-aarch64 AS qemu
-FROM $(RPI64_IMAGE) AS build
+FROM $(BULLSEYE_64_IMAGE) AS build
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apt update && apt install -y --no-install-recommends \
 	g++ \
-	pkg-config \
 	make \
-	libcamera-dev \
-	libfreetype-dev \
 	xxd \
-	wget
+	wget \
+	git \
+	cmake \
+	meson \
+	patch \
+	pkg-config \
+	python3-jinja2 \
+	python3-yaml \
+	python3-ply
 WORKDIR /s
 COPY . .
 RUN make -j$$(nproc)
 endef
-export DOCKERFILE_BUILD64
+export DOCKERFILE_BUILD_64
 
-build64: enable_multiarch
-	echo "$$DOCKERFILE_BUILD64" | docker build . -f - -t build64
-	docker run --rm -v $(PWD):/o build64 sh -c "mv /s/mtxrpicam_64 /o/"
+build_64: enable_multiarch
+	echo "$$DOCKERFILE_BUILD_64" | docker build . -f - -t build64
+	docker run --rm -v $(PWD):/o build64 sh -c "rm -rf /o/mtxrpicam_64 && mv /s/mtxrpicam_64 /o/"
 
-define DOCKERFILE_TEST32
+define DOCKERFILE_TEST_BULLSEYE_32
 FROM multiarch/qemu-user-static:x86_64-arm AS qemu
-FROM $(RPI32_IMAGE) AS build
+FROM $(BULLSEYE_32_IMAGE) AS build
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
-RUN apt update && apt install -y --no-install-recommends libcamera0 libfreetype6 && rm -rf /var/lib/apt/lists/*
 endef
-export DOCKERFILE_TEST32
+export DOCKERFILE_TEST_BULLSEYE_32
 
-test32: enable_multiarch
-	echo "$$DOCKERFILE_TEST32" | docker build . -f - -t test32
-	docker run --rm --platform=linux/arm/v6 -v $(PWD):/s -w /s test32 bash -c "TEST=1 ./mtxrpicam_32"
+test_bullseye_32: enable_multiarch
+	echo "$$DOCKERFILE_TEST_BULLSEYE_32" | docker build . -f - -t test_bullseye_32
+	docker run --rm --platform=linux/arm/v6 -v $(PWD):/s -w /s/mtxrpicam_32 test_bullseye_32 bash -c "LD_LIBRARY_PATH=. TEST=1 ./exe"
 
-define DOCKERFILE_TEST64
+define DOCKERFILE_TEST_BULLSEYE_64
 FROM multiarch/qemu-user-static:x86_64-aarch64 AS qemu
-FROM $(RPI64_IMAGE) AS build
+FROM $(BULLSEYE_64_IMAGE) AS build
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
-RUN apt update && apt install -y --no-install-recommends libcamera0 libfreetype6 && rm -rf /var/lib/apt/lists/*
 endef
-export DOCKERFILE_TEST64
+export DOCKERFILE_TEST_BULLSEYE_64
 
-test64: enable_multiarch
-	echo "$$DOCKERFILE_TEST64" | docker build . -f - -t test64
-	docker run --rm --platform=linux/arm64/v8 -v $(PWD):/s -w /s test64 bash -c "TEST=1 ./mtxrpicam_64"
+test_bullseye_64: enable_multiarch
+	echo "$$DOCKERFILE_TEST_BULLSEYE_64" | docker build . -f - -t test_bullseye_64
+	docker run --rm --platform=linux/arm64/v8 -v $(PWD):/s -w /s/mtxrpicam_64 test_bullseye_64 bash -c "LD_LIBRARY_PATH=. TEST=1 ./exe"
+
+define DOCKERFILE_TEST_BOOKWORM_32
+FROM multiarch/qemu-user-static:x86_64-arm AS qemu
+FROM $(BOOKWORM_32_IMAGE) AS build
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+endef
+export DOCKERFILE_TEST_BOOKWORM_32
+
+test_bookworm_32: enable_multiarch
+	echo "$$DOCKERFILE_TEST_BOOKWORM_32" | docker build . -f - -t test_bookworm_32
+	docker run --rm --platform=linux/arm/v6 -v $(PWD):/s -w /s/mtxrpicam_32 test_bookworm_32 bash -c "LD_LIBRARY_PATH=. TEST=1 ./exe"
+
+define DOCKERFILE_TEST_BOOKWORM_64
+FROM multiarch/qemu-user-static:x86_64-aarch64 AS qemu
+FROM $(BOOKWORM_64_IMAGE) AS build
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+endef
+export DOCKERFILE_TEST_BOOKWORM_64
+
+test_bookworm_64: enable_multiarch
+	echo "$$DOCKERFILE_TEST_BOOKWORM_64" | docker build . -f - -t test_bookworm_64
+	docker run --rm --platform=linux/arm64/v8 -v $(PWD):/s -w /s/mtxrpicam_64 test_bookworm_64 bash -c "LD_LIBRARY_PATH=. TEST=1 ./exe"


### PR DESCRIPTION
Related to https://github.com/bluenviron/mediamtx/issues/2581

libcamera and libfreetype are now embedded into the component.

This makes MediaMTX independent from the operating system and from libcamera, fixing current and future compatibility issues.