### PR TITLE
support displaying microseconds in text overlay (bluenviron/mediamtx#3866)

### DIFF
--- a/encoder.c
+++ b/encoder.c
@@ -5,7 +5,6 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-#include <time.h>
 
 #include <linux/videodev2.h>
 


### PR DESCRIPTION
Fixes bluenviron/mediamtx#3866