### PR TITLE
Merge request->controls instead of overwriting

### DIFF
--- a/camera.cpp
+++ b/camera.cpp
@@ -402,7 +402,9 @@ static void on_request_complete(Request *request) {
 
     {
         std::lock_guard<std::mutex> lock(camp->ctrls_mutex);
-        request->controls() = *camp->ctrls;
+        request->controls().merge(
+            *camp->ctrls,
+            libcamera::ControlList::MergePolicy::OverwriteExisting);
         camp->ctrls->clear();
     }
 


### PR DESCRIPTION
Bit of a long story here, but I'm trying to get mediamtx working on a pi with libcamera 0.7.0 (Nix stopped packaging mediamtx with rpi camera support and I'm trying to add support for that back in to their package). The latest versions of libcamera are more strict about changing controls; assignment is no longer allowed since https://github.com/raspberrypi/libcamera/commit/310cd8bc0756717cde97fe5b083926f6d6931f58 so I kept seeing the error "Overwriting Request::controls() is not allowed" when initialising the pi camera source.

I've changed the controls assignment to a merge and overwrite instead. I've tested this against libcamera 0.7.0+rpt20260205 and 0.5.2+rpt20250903 and both work fine embedded in mediamtx. I haven't been able to test all builds for non-pi platforms as I'm having issues with the docker builder which I haven't had time to diagnose.