### PR TITLE
use timestamp of frame in text overlay (bluenviron/mediamtx#2733)

### DIFF
--- a/camera.cpp
+++ b/camera.cpp
@@ -393,10 +393,24 @@ static void on_request_complete(Request *request) {
         }
     }
 
+    uint64_t dts = buffer->metadata().timestamp / 1000;
+
+    struct timespec dts_now_ts;
+    clock_gettime(CLOCK_MONOTONIC, &dts_now_ts);
+    uint64_t dts_now =
+        (uint64_t)dts_now_ts.tv_sec * 1000000 + dts_now_ts.tv_nsec / 1000;
+
+    struct timespec ntp_ts;
+    clock_gettime(CLOCK_REALTIME, &ntp_ts);
+    uint64_t ntp = (uint64_t)ntp_ts.tv_sec * 1000000 + ntp_ts.tv_nsec / 1000;
+
+    // improve NTP precision by subtracting the difference between now and the
+    // moment the frame was taken
+    ntp -= dts_now - dts;
+
     camp->frame_cb(camp->mapped_buffers.at(buffer),
                    buffer->planes()[0].fd.get(), buffer_size(buffer->planes()),
-                   buffer->metadata().timestamp / 1000,
-                   secondary_buffer_mapped);
+                   dts, ntp, secondary_buffer_mapped);
 
     request->reuse(Request::ReuseFlag::ReuseBuffers);
 

--- a/camera.h
+++ b/camera.h
@@ -6,8 +6,8 @@
 typedef void camera_t;
 
 typedef void (*camera_frame_cb)(uint8_t *buffer_mapped, int buffer_fd,
-                                uint64_t buffer_size, uint64_t timestamp,
-                                uint8_t *secondary_buffer_mapped);
+                                uint64_t buffer_size, uint64_t dts,
+                                uint64_t ntp, uint8_t *secondary_buffer_mapped);
 
 typedef void (*camera_error_cb)();
 

--- a/encoder.c
+++ b/encoder.c
@@ -23,7 +23,7 @@ static void set_error(const char *format, ...) {
 const char *encoder_get_error() { return errbuf; }
 
 typedef void (*encode_cb)(void *enc, uint8_t *mapped_buffer, int buffer_fd,
-                          size_t size, uint64_t ts);
+                          size_t size, uint64_t dts, uint64_t ntp);
 
 typedef void (*reload_params_cb)(void *enc, const parameters_t *params);
 
@@ -114,9 +114,10 @@ failed:
 }
 
 void encoder_encode(encoder_t *enc, uint8_t *mapped_buffer, int buffer_fd,
-                    size_t size, uint64_t ts) {
+                    size_t size, uint64_t dts, uint64_t ntp) {
     encoder_priv_t *encp = (encoder_priv_t *)enc;
-    encp->encode(encp->implementation, mapped_buffer, buffer_fd, size, ts);
+    encp->encode(encp->implementation, mapped_buffer, buffer_fd, size, dts,
+                 ntp);
 }
 
 void encoder_reload_params(encoder_t *enc, const parameters_t *params) {

--- a/encoder.h
+++ b/encoder.h
@@ -6,13 +6,14 @@
 typedef void encoder_t;
 
 typedef void (*encoder_output_cb)(const uint8_t *buffer_mapped,
-                                  uint64_t buffer_size, uint64_t timestamp);
+                                  uint64_t buffer_size, uint64_t dts,
+                                  uint64_t ntp);
 
 const char *encoder_get_error();
 bool encoder_create(const parameters_t *params, int stride, int colorspace,
                     encoder_output_cb output_cb, encoder_t **enc);
 void encoder_encode(encoder_t *enc, uint8_t *buffer_mapped, int buffer_fd,
-                    size_t buffer_size, uint64_t timestamp);
+                    size_t buffer_size, uint64_t dts, uint64_t ntp);
 void encoder_reload_params(encoder_t *enc, const parameters_t *params);
 void encoder_destroy(encoder_t *enc);
 

--- a/encoder_hardware_h264.c
+++ b/encoder_hardware_h264.c
@@ -28,6 +28,7 @@ const char *encoder_hardware_h264_get_error() { return errbuf; }
 typedef struct {
     int fd;
     void **capture_buffers;
+    uint64_t *ntp_timestamps;
     int buffer_count;
     int cur_buffer;
     encoder_hardware_h264_output_cb output_cb;
@@ -80,10 +81,11 @@ static void *output_thread(void *userdata) {
         const uint8_t *mapped =
             (const uint8_t *)encp->capture_buffers[buf.index];
         int size = buf.m.planes[0].bytesused;
-        uint64_t ts = ((uint64_t)buf.timestamp.tv_sec * (uint64_t)1000000) +
-                      (uint64_t)buf.timestamp.tv_usec;
+        uint64_t dts = ((uint64_t)buf.timestamp.tv_sec * (uint64_t)1000000) +
+                       (uint64_t)buf.timestamp.tv_usec;
+        uint64_t ntp = encp->ntp_timestamps[buf.index];
 
-        encp->output_cb(mapped, size, ts);
+        encp->output_cb(mapped, size, dts, ntp);
 
         res = ioctl(encp->fd, VIDIOC_QBUF, &buf);
         if (res != 0) {
@@ -232,6 +234,7 @@ bool encoder_hardware_h264_create(const parameters_t *params, int stride,
     }
 
     encp->capture_buffers = malloc(sizeof(void *) * reqbufs.count);
+    encp->ntp_timestamps = malloc(sizeof(uint64_t) * reqbufs.count);
 
     struct v4l2_plane planes[VIDEO_MAX_PLANES];
     struct v4l2_buffer buffer = {0};
@@ -299,11 +302,14 @@ failed:
 
 void encoder_hardware_h264_encode(encoder_hardware_h264_t *enc,
                                   uint8_t *buffer_mapped, int buffer_fd,
-                                  size_t buffer_size, uint64_t timestamp) {
+                                  size_t buffer_size, uint64_t dts,
+                                  uint64_t ntp) {
     encoder_hardware_h264_priv_t *encp = (encoder_hardware_h264_priv_t *)enc;
 
     int index = encp->cur_buffer++;
     encp->cur_buffer %= encp->buffer_count;
+
+    encp->ntp_timestamps[index] = ntp;
 
     struct v4l2_buffer buf = {0};
     struct v4l2_plane planes[VIDEO_MAX_PLANES] = {0};
@@ -312,8 +318,8 @@ void encoder_hardware_h264_encode(encoder_hardware_h264_t *enc,
     buf.field = V4L2_FIELD_NONE;
     buf.memory = V4L2_MEMORY_DMABUF;
     buf.length = 1;
-    buf.timestamp.tv_sec = timestamp / 1000000;
-    buf.timestamp.tv_usec = timestamp % 1000000;
+    buf.timestamp.tv_sec = dts / 1000000;
+    buf.timestamp.tv_usec = dts % 1000000;
     buf.m.planes = planes;
     buf.m.planes[0].m.fd = buffer_fd;
     buf.m.planes[0].bytesused = buffer_size;
@@ -363,5 +369,6 @@ void encoder_hardware_h264_destroy(encoder_hardware_h264_t *enc) {
     close(encp->fd);
 
     free(encp->capture_buffers);
+    free(encp->ntp_timestamps);
     free(encp);
 }

--- a/encoder_hardware_h264.h
+++ b/encoder_hardware_h264.h
@@ -9,7 +9,7 @@ typedef void encoder_hardware_h264_t;
 
 typedef void (*encoder_hardware_h264_output_cb)(const uint8_t *buffer_mapped,
                                                 uint64_t buffer_size,
-                                                uint64_t timestamp);
+                                                uint64_t dts, uint64_t ntp);
 
 const char *encoder_hardware_h264_get_error();
 bool encoder_hardware_h264_create(const parameters_t *params, int stride,
@@ -18,7 +18,8 @@ bool encoder_hardware_h264_create(const parameters_t *params, int stride,
                                   encoder_hardware_h264_t **enc);
 void encoder_hardware_h264_encode(encoder_hardware_h264_t *enc,
                                   uint8_t *buffer_mapped, int buffer_fd,
-                                  size_t buffer_size, uint64_t timestamp);
+                                  size_t buffer_size, uint64_t dts,
+                                  uint64_t ntp);
 void encoder_hardware_h264_reload_params(encoder_hardware_h264_t *enc,
                                          const parameters_t *params);
 void encoder_hardware_h264_destroy(encoder_hardware_h264_t *enc);

--- a/encoder_jpeg.c
+++ b/encoder_jpeg.c
@@ -24,7 +24,8 @@ typedef struct {
     pthread_t thread;
     bool data_queued;
     uint8_t *data_buffer;
-    uint64_t data_timestamp;
+    uint64_t data_dts;
+    uint64_t data_ntp;
     encoder_jpeg_output_cb output_cb;
 } encoder_jpeg_priv_t;
 
@@ -86,7 +87,8 @@ static void *thread_main(void *userdata) {
         }
 
         uint8_t *buffer = encp->data_buffer;
-        uint64_t timestamp = encp->data_timestamp;
+        uint64_t dts = encp->data_dts;
+        uint64_t ntp = encp->data_ntp;
         encp->data_queued = false;
 
         pthread_cond_signal(&encp->cond);
@@ -98,7 +100,7 @@ static void *thread_main(void *userdata) {
         save_as_jpeg(encp->width, encp->height, encp->quality, encp->stride,
                      buffer, &out_buf, &out_size);
 
-        encp->output_cb(out_buf, out_size, timestamp);
+        encp->output_cb(out_buf, out_size, dts, ntp);
 
         free(out_buf);
     }
@@ -125,8 +127,8 @@ bool encoder_jpeg_create(int width, int height, int quality, int stride,
     return true;
 }
 
-void encoder_jpeg_encode(encoder_jpeg_t *enc, uint8_t *buffer,
-                         uint64_t timestamp) {
+void encoder_jpeg_encode(encoder_jpeg_t *enc, uint8_t *buffer, uint64_t dts,
+                         uint64_t ntp) {
     encoder_jpeg_priv_t *encp = (encoder_jpeg_priv_t *)enc;
 
     pthread_mutex_lock(&encp->mutex);
@@ -137,7 +139,8 @@ void encoder_jpeg_encode(encoder_jpeg_t *enc, uint8_t *buffer,
 
     encp->data_queued = true;
     encp->data_buffer = buffer;
-    encp->data_timestamp = timestamp;
+    encp->data_dts = dts;
+    encp->data_ntp = ntp;
 
     pthread_cond_signal(&encp->cond);
 

--- a/encoder_jpeg.h
+++ b/encoder_jpeg.h
@@ -6,12 +6,13 @@
 typedef void encoder_jpeg_t;
 
 typedef void (*encoder_jpeg_output_cb)(const uint8_t *mapped, uint64_t size,
-                                       uint64_t ts);
+                                       uint64_t dts, uint64_t ntp);
 
 const char *encoder_jpeg_get_error();
 bool encoder_jpeg_create(int width, int height, int quality, int stride,
                          encoder_jpeg_output_cb output_cb,
                          encoder_jpeg_t **enc);
-void encoder_jpeg_encode(encoder_jpeg_t *enc, uint8_t *mapped, uint64_t ts);
+void encoder_jpeg_encode(encoder_jpeg_t *enc, uint8_t *mapped, uint64_t dts,
+                         uint64_t ntp);
 
 #endif

--- a/encoder_software_h264.cpp
+++ b/encoder_software_h264.cpp
@@ -32,11 +32,12 @@ typedef struct {
     pthread_t thread;
     bool data_queued;
     uint8_t *data_buffer;
-    uint64_t data_timestamp;
+    uint64_t data_dts;
+    uint64_t data_ntp;
 } encoder_software_h264_priv_t;
 
 static void encode(encoder_software_h264_priv_t *encp, uint8_t *buffer,
-                   uint64_t timestamp) {
+                   uint64_t dts, uint64_t ntp) {
     pthread_mutex_lock(&encp->mutex);
 
     encp->pic.pData[0] = buffer; // Y
@@ -45,7 +46,7 @@ static void encode(encoder_software_h264_priv_t *encp, uint8_t *buffer,
     encp->pic.pData[2] =
         encp->pic.pData[1] +
         (encp->pic.iStride[0] / 2) * (encp->params->height / 2); // V
-    encp->pic.uiTimeStamp = timestamp / 1000000;
+    encp->pic.uiTimeStamp = dts / 1000000;
 
     memset(&encp->info, 0, sizeof(SFrameBSInfo));
     int res = encp->encoder->EncodeFrame(&encp->pic, &encp->info);
@@ -66,7 +67,7 @@ static void encode(encoder_software_h264_priv_t *encp, uint8_t *buffer,
                 frame_size += layer_info->pNalLengthInByte[j];
             }
 
-            encp->output_cb(layer_info->pBsBuf, frame_size, timestamp);
+            encp->output_cb(layer_info->pBsBuf, frame_size, dts, ntp);
         }
     }
 }
@@ -83,14 +84,15 @@ static void *thread_main(void *userdata) {
         }
 
         uint8_t *buffer = encp->data_buffer;
-        uint64_t timestamp = encp->data_timestamp;
+        uint64_t dts = encp->data_dts;
+        uint64_t ntp = encp->data_ntp;
         encp->data_queued = false;
 
         pthread_cond_signal(&encp->queue_cond);
 
         pthread_mutex_unlock(&encp->queue_mutex);
 
-        encode(encp, buffer, timestamp);
+        encode(encp, buffer, dts, ntp);
     }
 
     return NULL;
@@ -205,7 +207,8 @@ failed:
 
 void encoder_software_h264_encode(encoder_software_h264_t *enc,
                                   uint8_t *buffer_mapped, int buffer_fd,
-                                  size_t buffer_size, uint64_t timestamp) {
+                                  size_t buffer_size, uint64_t dts,
+                                  uint64_t ntp) {
     encoder_software_h264_priv_t *encp = (encoder_software_h264_priv_t *)enc;
 
     pthread_mutex_lock(&encp->queue_mutex);
@@ -216,7 +219,8 @@ void encoder_software_h264_encode(encoder_software_h264_t *enc,
 
     encp->data_queued = true;
     encp->data_buffer = buffer_mapped;
-    encp->data_timestamp = timestamp;
+    encp->data_dts = dts;
+    encp->data_ntp = ntp;
 
     pthread_cond_signal(&encp->queue_cond);
 

--- a/encoder_software_h264.h
+++ b/encoder_software_h264.h
@@ -7,7 +7,7 @@ typedef void encoder_software_h264_t;
 
 typedef void (*encoder_software_h264_output_cb)(const uint8_t *buffer_mapped,
                                                 uint64_t buffer_size,
-                                                uint64_t timestamp);
+                                                uint64_t dts, uint64_t ntp);
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,7 +20,8 @@ bool encoder_software_h264_create(const parameters_t *params, int stride,
                                   encoder_software_h264_t **enc);
 void encoder_software_h264_encode(encoder_software_h264_t *enc,
                                   uint8_t *buffer_mapped, int buffer_fd,
-                                  size_t buffer_size, uint64_t timestamp);
+                                  size_t buffer_size, uint64_t dts,
+                                  uint64_t ntp);
 void encoder_software_h264_reload_params(encoder_software_h264_t *enc,
                                          const parameters_t *params);
 

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ static encoder_t *enc;
 static encoder_jpeg_t *enc_jpeg = NULL;
 
 static void on_frame(uint8_t *buffer_mapped, int buffer_fd,
-                     uint64_t buffer_size, uint64_t timestamp,
+                     uint64_t buffer_size, uint64_t dts, uint64_t ntp,
                      uint8_t *secondary_buffer_mapped) {
     // mapped DMA buffers require a DMA_BUF_IOCTL_SYNC before and after usage.
     // https://forums.raspberrypi.com/viewtopic.php?t=352554
@@ -33,28 +33,30 @@ static void on_frame(uint8_t *buffer_mapped, int buffer_fd,
     dma_sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_RW;
     ioctl(buffer_fd, DMA_BUF_IOCTL_SYNC, &dma_sync);
 
-    text_draw(text, buffer_mapped);
+    text_draw(text, buffer_mapped, ntp);
 
     dma_sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_RW;
     ioctl(buffer_fd, DMA_BUF_IOCTL_SYNC, &dma_sync);
 
-    encoder_encode(enc, buffer_mapped, buffer_fd, buffer_size, timestamp);
+    encoder_encode(enc, buffer_mapped, buffer_fd, buffer_size, dts, ntp);
 
     if (enc_jpeg != NULL && secondary_buffer_mapped != NULL) {
-        encoder_jpeg_encode(enc_jpeg, secondary_buffer_mapped, timestamp);
+        encoder_jpeg_encode(enc_jpeg, secondary_buffer_mapped, dts, ntp);
     }
 }
 
 static void on_encoder_output(const uint8_t *buffer_mapped,
-                              uint64_t buffer_size, uint64_t timestamp) {
+                              uint64_t buffer_size, uint64_t dts,
+                              uint64_t ntp) {
     pthread_mutex_lock(&pipe_out_mutex);
-    pipe_write_data(pipe_out_fd, buffer_mapped, buffer_size, timestamp);
+    pipe_write_data(pipe_out_fd, buffer_mapped, buffer_size, dts, ntp);
     pthread_mutex_unlock(&pipe_out_mutex);
 }
 
-static void on_jpeg_output(const uint8_t *buf, uint64_t size, uint64_t ts) {
+static void on_jpeg_output(const uint8_t *buf, uint64_t size, uint64_t dts,
+                           uint64_t ntp) {
     pthread_mutex_lock(&pipe_out_mutex);
-    pipe_write_secondary_data(pipe_out_fd, buf, size, ts);
+    pipe_write_secondary_data(pipe_out_fd, buf, size, dts, ntp);
     pthread_mutex_unlock(&pipe_out_mutex);
 }
 

--- a/pipe.c
+++ b/pipe.c
@@ -25,24 +25,26 @@ void pipe_write_ready(int fd) {
     write(fd, buf, n);
 }
 
-void pipe_write_data(int fd, const uint8_t *mapped, uint32_t size,
-                     uint64_t ts) {
+void pipe_write_data(int fd, const uint8_t *mapped, uint32_t size, uint64_t dts,
+                     uint64_t ntp) {
     char head[] = {'d'};
-    size += 1 + sizeof(uint64_t);
+    size += 1 + 2 * sizeof(uint64_t);
     write(fd, &size, 4);
     write(fd, head, 1);
-    write(fd, &ts, sizeof(uint64_t));
-    write(fd, mapped, size - 1 - sizeof(uint64_t));
+    write(fd, &dts, sizeof(uint64_t));
+    write(fd, &ntp, sizeof(uint64_t));
+    write(fd, mapped, size - 1 - 2 * sizeof(uint64_t));
 }
 
 void pipe_write_secondary_data(int fd, const uint8_t *mapped, uint32_t size,
-                               uint64_t ts) {
+                               uint64_t dts, uint64_t ntp) {
     char head[] = {'s'};
-    size += 1 + sizeof(uint64_t);
+    size += 1 + 2 * sizeof(uint64_t);
     write(fd, &size, 4);
     write(fd, head, 1);
-    write(fd, &ts, sizeof(uint64_t));
-    write(fd, mapped, size - 1 - sizeof(uint64_t));
+    write(fd, &dts, sizeof(uint64_t));
+    write(fd, &ntp, sizeof(uint64_t));
+    write(fd, mapped, size - 1 - 2 * sizeof(uint64_t));
 }
 
 uint32_t pipe_read(int fd, uint8_t **pbuf) {

--- a/pipe.h
+++ b/pipe.h
@@ -6,9 +6,10 @@
 
 void pipe_write_error(int fd, const char *format, ...);
 void pipe_write_ready(int fd);
-void pipe_write_data(int fd, const uint8_t *mapped, uint32_t size, uint64_t ts);
+void pipe_write_data(int fd, const uint8_t *mapped, uint32_t size, uint64_t dts,
+                     uint64_t ntp);
 void pipe_write_secondary_data(int fd, const uint8_t *mapped, uint32_t size,
-                               uint64_t ts);
+                               uint64_t dts, uint64_t ntp);
 uint32_t pipe_read(int fd, uint8_t **pbuf);
 
 #endif

--- a/text.c
+++ b/text.c
@@ -1,5 +1,4 @@
 #include <pthread.h>
-#include <sys/time.h>
 #include <time.h>
 
 #include <ft2build.h>
@@ -228,17 +227,19 @@ void text_destroy(text_t *text) {
     free(textp);
 }
 
-void text_draw(text_t *text, uint8_t *buf) {
+void text_draw(text_t *text, uint8_t *buf, uint64_t ntp) {
     text_priv_t *textp = (text_priv_t *)text;
 
     pthread_mutex_lock(&textp->mutex);
 
     if (textp->library != NULL) {
-        struct timeval now;
-        gettimeofday(&now, NULL);
+        struct timeval tv = {
+            .tv_sec = ntp / 1000000,
+            .tv_usec = ntp % 1000000,
+        };
 
         char buffer[256];
-        extended_strftime(buffer, 256, textp->text_overlay, &now);
+        extended_strftime(buffer, 256, textp->text_overlay, &tv);
 
         draw_rect(buf, textp->stride, textp->height, 7, 7,
                   get_text_width(textp->face, buffer) + 10, 34);

--- a/text.h
+++ b/text.h
@@ -12,6 +12,6 @@ const char *text_get_error();
 bool text_create(const parameters_t *params, int stride, text_t **text);
 void text_reload_params(text_t *text, const parameters_t *params);
 void text_destroy(text_t *text);
-void text_draw(text_t *text, uint8_t *buf);
+void text_draw(text_t *text, uint8_t *buf, uint64_t ntp);
 
 #endif


### PR DESCRIPTION
Fixes bluenviron/mediamtx#2733